### PR TITLE
add plugin defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ panelbuttons: http://ckeditor.com/addon/panelbutton
 
 Demo: https://www.youtube.com/watch?v=ULDeTUs-xHE
 
+## Configuration
+
+You can configure the plugin using the following parameters:
+
+```javascript
+CKEDITOR.replace( 'myeditor', {
+   // ...
+   qtRows: 10,            // number of rows to show
+   qtColumns: 8,          // number of columns to show
+   qtStyle: '',           // extra style to apply 
+   qtWidth: '100%',
+   qtBordered: true,      // table is bordered by default      
+   qtStriped: true,       // table is striped by default
+   qtHover: true,         // table has hover effect by default
+   qtCondensed: true,     // table is condensed by default
+   qtPreviewSize: '14px',
+   qtPreviewBorder: '1px solid #aaa',
+   qtPreviewBackground: '#e5e5e5'   
+   // ...
+});
+```
 
 ##Other Bootstrap 3 software for CKEditor
 

--- a/plugin.js
+++ b/plugin.js
@@ -9,6 +9,10 @@
 			quickStyle = conf.qtStyle || null,
 			quickClass = conf.qtClass || '',
 			quickWidth = conf.qtWidth || '100%',
+			quickStriped = conf.qtStripes || false,
+			quickBordered = conf.qtBordered || false,
+			quickHover = conf.qtHover || false,
+			quickCondensed = conf.qtCondensed || false,
 			quickPreviewSize = conf.qtPreviewSize || '14px',
 			quickPreviewBorder = conf.qtPreviewBorder || '1px solid #aaa',
 			quickPreviewBackground = conf.qtPreviewBackground || '#e5e5e5';
@@ -123,16 +127,19 @@
 
 				// Data object class: Checkbox name;
 				var btdata = {
-					'table-bordered': lang.bt_table.addBorders,
-					'table-striped': lang.bt_table.addStripes,
-					'table-hover': lang.bt_table.addHover,
-					'table-condensed': lang.bt_table.compactStyle,
+					'table-bordered': {label: lang.bt_table.addBorders, val: quickBordered},
+					'table-striped': {label: lang.bt_table.addStripes, val: quickStriped},
+					'table-hover': {label: lang.bt_table.addHover, val: quickHover},
+					'table-condensed': {label: lang.bt_table.compactStyle, val: quickCondensed},
 				};
 				panel.bootstrapdata = [];
 				for (item in btdata) {
+					panel.bootstrapdata[item] = btdata[item].val;
 					var	dialogElement = new CKEDITOR.dom.element.createFromHtml(
-						'<div><label><input type="checkbox" name="' + item + '">' + btdata[item]
-				 			+ '</label></div>');
+						'<div><label><input type="checkbox" name="' + item + '"'
+						    + ((btdata[item].val)?' checked="checked"':'')
+						    +'>' + btdata[item].label
+						    + '</label></div>');
 
 					dialogElement.find('input').$[0].onchange = function() {
 						return panel.bootstrapdata[this.name] = this.checked;


### PR DESCRIPTION
This patch adds options `qtBordered`, `qtStriped`, `qtHover` and `qtCondensed` to the config, so it is possible for example to have "bordered" checked by default.

Example:

```javascript
CKEDITOR.replace( 'myeditor', {
   // ...
   qtBordered: true, // quick table is bordered by default
   qtStriped: true,  // quick table is striped by default
   qtHover: true,    // quick table has hover effect by default
   qtCondensed: true // table is condensed by default
   // ...
});
```
While it would be more elegant IMHO to have all the qt* options as a separate config subobject,  original quicktable doesn't have that either, I decided to leave it that way. 
